### PR TITLE
Some bugfixes and adding logo stretcher

### DIFF
--- a/scripts/arthashdungeon.py
+++ b/scripts/arthashdungeon.py
@@ -1,6 +1,6 @@
 #! /usr/bin/python3
 from datetime import datetime
-from PIL import Image, ImageFilter, ImageDraw, ImageFont, ImageColor
+from PIL import Image, ImageDraw, ImageColor
 import json
 import locale
 import math
@@ -9,48 +9,15 @@ import random
 import subprocess
 import time
 import sys
+import vicariousbitcoin
+import vicarioustext
 
 bitcoinLogosFile="/home/bitcoin/nodeyez/images/arthash-dungeon-bitcoin-logos.png"
 bitcoinTilesFile="/home/bitcoin/nodeyez/images/arthash-dungeon-bitcoin-tiles.png"
 outputFile="/home/bitcoin/images/arthashdungeon.png"
 color000000=ImageColor.getrgb("#000000")
 colorFFFFFF=ImageColor.getrgb("#ffffff")
-fontDeja12=ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",12)
-fontDeja24=ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",24)
 maze=[]
-
-def getdateandtime():
-    now = datetime.utcnow()
-    return now.strftime("%Y-%m-%d %H:%M:%S")
-def getfont(size):
-    if size == 12:
-        return fontDeja12
-    if size == 24:
-        return fontDeja24
-
-def drawcenteredtext(draw, s, fontsize, x, y):
-    thefont = getfont(fontsize)
-    sw,sh = draw.textsize(s, thefont)
-    ox,oy = thefont.getoffset(s)
-    sw += ox
-    sh += oy
-    draw.text(xy=(x-(sw/2),y-(sh/2)), text=s, font=thefont, fill=colorFFFFFF)
-
-def drawbottomlefttext(draw, s, fontsize, x, y):
-    thefont = getfont(fontsize)
-    sw,sh = draw.textsize(s, thefont)
-    ox,oy = thefont.getoffset(s)
-    sw += ox
-    sh += oy
-    draw.text(xy=(x,y-sh), text=s, font=thefont, fill=colorFFFFFF)
-
-def drawbottomrighttext(draw, s, fontsize, x, y):
-    thefont = getfont(fontsize)
-    sw,sh = draw.textsize(s, thefont)
-    ox,oy = thefont.getoffset(s)
-    sw += ox
-    sh += oy
-    draw.text(xy=(x-sw,y-sh), text=s, font=thefont, fill=colorFFFFFF)
 
 def dfsmazegen(x, y, d, t):
     global maze
@@ -113,7 +80,7 @@ def dfsmazegen(x, y, d, t):
         maze[x][y] = mynode
 
 def createimage(blocknumber=1, width=480, height=320):
-    blockhash = getblockhash(blocknumber)
+    blockhash = vicariousbitcoin.getblockhash(blocknumber)
     outputFileBlock = outputFile
     if len(sys.argv) > 1:
         outputFileBlock = outputFile.replace(".png","-" + str(blocknumber) + ".png")
@@ -266,28 +233,9 @@ def createimage(blocknumber=1, width=480, height=320):
     # draw top bar
     #  - level
     #  - sats
-    drawcenteredtext(draw, "Blockhash Dungeon For Level " + str(blocknumber), 24, int(width/2), int(padtop/2))
+    vicarioustext.drawlefttext(draw, "Blockhash Dungeon", 24, 0, int(padtop/2), colorFFFFFF, True)
+    vicarioustext.drawrighttext(draw, "Level " + str(blocknumber), 24, width, int(padtop/2), colorFFFFFF, True)
     im.save(outputFileBlock)
-
-def getcurrentblock():
-    cmd = "bitcoin-cli getblockchaininfo"
-    try:
-        cmdoutput = subprocess.check_output(cmd, shell=True).decode("utf-8")
-        j = json.loads(cmdoutput)
-        blockcurrent = int(j["blocks"])
-        return blockcurrent
-    except subprocess.CalledProcessError as e:
-        print(e)
-        return 1
-
-def getblockhash(blocknumber=1):
-    cmd = "bitcoin-cli getblockhash " + str(blocknumber)
-    try:
-        cmdoutput = subprocess.check_output(cmd, shell=True).decode("utf-8")
-        return cmdoutput
-    except subprocess.CalledProcessError as e:
-        print(e)
-        return "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 if len(sys.argv) > 1:
     if len(sys.argv) > 3:
@@ -296,6 +244,6 @@ if len(sys.argv) > 1:
         createimage(int(sys.argv[1]))
 else:
     while True:
-        blocknumber = getcurrentblock()
+        blocknumber = vicariousbitcoin.getcurrentblock()
         createimage(blocknumber)
         time.sleep(300)

--- a/scripts/channelbalance.py
+++ b/scripts/channelbalance.py
@@ -1,6 +1,8 @@
 #! /usr/bin/python3
 from PIL import Image, ImageDraw, ImageColor
+import glob
 import math
+import os
 import time
 import vicariousbitcoin
 import vicarioustext
@@ -11,6 +13,21 @@ colorBackground=ImageColor.getrgb("#000000")
 colorBarOutline=ImageColor.getrgb("#770044")
 colorBarFilled=ImageColor.getrgb("#aa3377")
 
+def clearOldImages(pages):
+    # find all images matching 
+    imageMask = outputFile.replace(".png", "-*.png")
+    files=glob.glob(imageMask)
+    for filename in files:
+        fileisgood = False
+        for checkfilenumber in range(pages):
+            checkfilename = outputFile.replace(".png","-" + str(checkfilenumber+1) + ".png")
+            if checkfilename == filename:
+                #print(f"file {filename} is ok to keep")
+                fileisgood = True
+        if not fileisgood:
+            print(f"file {filename} is no longer needed and will be deleted")
+            os.remove(filename)
+
 def createimage(channels, firstidx, lastidx, pagenum, pagesize, width=480, height=320):
     padding=4
     outlinewidth=2
@@ -20,7 +37,7 @@ def createimage(channels, firstidx, lastidx, pagenum, pagesize, width=480, heigh
     dataheight = int(math.floor((height - (padtop+padbottom)) / pagesize))
     im = Image.new(mode="RGB", size=(width, height))
     draw = ImageDraw.Draw(im)
-    pageoutputFile = ("-" + str(pagenum) + ".").join(outputFile.rsplit(".", 1))
+    pageoutputFile = outputFile.replace(".png","-" + str(pagenum) + ".png")
     # Header
     vicarioustext.drawcenteredtext(draw, "Lightning Channel Balances", 24, int(width/2), int(padtop/2), colorFFFFFF, True)
     # Channel info
@@ -60,6 +77,7 @@ while True:
     channelcount = len(channels)
     pagesize = 8
     pages = int(math.ceil(float(channelcount) / float(pagesize)))
+    clearOldImages(pages)
     for pagenum in range(1, (pages+1)):
         firstidx = ((pagenum-1)*pagesize)
         lastidx = (pagenum*pagesize)-1

--- a/scripts/debug.py
+++ b/scripts/debug.py
@@ -22,20 +22,21 @@ def checkimageage(imagename="debug.png", threshold=monitorage):
 
 def checkforoldimages():
     output = ""
-#    output = output + checkimageage("blockheight*.png", 2)
+    output = output + checkimageage("arthashdungeon*.png", 15)
+    output = output + checkimageage("blockheight*.png", 2)
     output = output + checkimageage("channelbalance*.png", 30)
     output = output + checkimageage("compassminingstatus*.png", 5)
     output = output + checkimageage("debug*.png", 1)
     output = output + checkimageage("difficultyepoch*.png", 9)
     output = output + checkimageage("f2pool*.png", 10)
-#    output = output + checkimageage("ipaddress*.png", 2)
+    output = output + checkimageage("ipaddress*.png", 2)
     output = output + checkimageage("mempoolblocks*.png", 5)
     output = output + checkimageage("minerstatus*.png", 1)
     output = output + checkimageage("rof*.png", 15)
     output = output + checkimageage("satsperusd*.png", 60)
     output = output + checkimageage("slushpool*.png", 10)
     output = output + checkimageage("sysinfo*.png", 1)
-#    output = output + checkimageage("utcclock*.png", 1)
+    output = output + checkimageage("utcclock*.png", 1)
     return output
 
 def getoldimages():

--- a/scripts/ipaddress.py
+++ b/scripts/ipaddress.py
@@ -25,7 +25,7 @@ def createimage(width=480, height=320):
     currentip = getcurrentip()
     im = Image.new(mode="RGB", size=(width, height))
     draw = ImageDraw.Draw(im)
-    vicarioustext.drawcenteredtext(draw, str(currentip), 48, int(width/2), int(height/2))
+    vicarioustext.drawcenteredtext(draw, str(currentip), 36, int(width/2), int(height/2), colorFFFFFF, True)
     vicarioustext.drawbottomrighttext(draw, "as of " + vicarioustext.getdateandtime(), 12, width, height)
     im.save(outputFile)
 

--- a/scripts/logo.py
+++ b/scripts/logo.py
@@ -1,0 +1,57 @@
+#! /usr/bin/python3
+from PIL import Image, ImageDraw
+
+sourceFile="/home/bitcoin/nodeyez/images/nodeyez-catseyes.png"
+outputFile="/home/bitcoin/images/logo.png"
+stretchEdge=True
+
+def createimage(width=480, height=320):
+
+    sourceImage=Image.open(sourceFile)
+    sourceWidth=int(sourceImage.getbbox()[2])
+    sourceHeight=int(sourceImage.getbbox()[3])
+    sourceRatio=float(sourceWidth)/float(sourceHeight)
+
+    imageRatio=float(width)/float(height)
+
+    if sourceRatio > imageRatio:
+        print("need to extend top and bottom")
+        newSourceHeight=int(sourceWidth/imageRatio)
+        print(f"original width x height is {sourceWidth} x {sourceHeight}.  New ratio height {newSourceHeight}")
+        offset = int((newSourceHeight-sourceHeight)/2)
+        imTaller = Image.new(mode="RGB", size=(sourceWidth, newSourceHeight))
+        imTaller.paste(sourceImage, (0, offset))
+        if stretchEdge:
+            imLine = sourceImage.crop((0,0,sourceWidth,1))
+            for y in range(offset):
+                imTaller.paste(imLine, (0, y))
+            imLine = sourceImage.crop((0,sourceHeight-1,sourceWidth,sourceHeight))
+            for y in range(offset):
+                imTaller.paste(imLine, (0, y+offset+sourceHeight))
+        im = imTaller.resize(size=(width,height))
+
+    if imageRatio > sourceRatio:
+        print("need to extend sides")
+        newSourceWidth=int(sourceHeight * imageRatio)
+        print(f"original width x height is {sourceWidth} x {sourceHeight}.  New ratio width {newSourceWidth}")
+        offset = int((newSourceWidth-sourceWidth)/2)
+        imWider = Image.new(mode="RGB", size=(newSourceWidth, sourceHeight))
+        imWider.paste(sourceImage, (offset, 0))
+        if stretchEdge:
+            imLine = sourceImage.crop((0,0,1,sourceHeight))
+            for x in range(offset):
+                imWider.paste(imLine, (x, 0))
+            imLine = sourceImage.crop((sourceWidth-1,0,sourceWidth,sourceHeight))
+            for x in range(offset):
+                imWider.paste(imLine, (x+offset+sourceWidth, 0))
+        im = imWider.resize(size=(width,height))
+
+    if imageRatio == sourceRatio:
+        print("same ratio")
+        im = sourceImage.resize(size=(width,height))
+
+
+    im.save(outputFile)
+
+
+createimage()

--- a/scripts/rofstatus.py
+++ b/scripts/rofstatus.py
@@ -33,11 +33,6 @@ def createimage(nodesonline, nodeschannel, nodesinfos, nodes, width=480, height=
     # for non-existant channels between nodes
     breaksize=20
     breakcolor=coloroffline
-    #btt="X"
-    #btw,bth=draw.textsize(btt,ringfont)
-    #ox,oy=ringfont.getoffset(btt)
-    #btw+=ox
-    #bth+=oy
     # draw the main ring
     draw.ellipse(xy=(padding, padding, height-padding, height-padding), outline=colorcircle, width=thickness)
     # draw the crosscutting from channels
@@ -81,7 +76,6 @@ def createimage(nodesonline, nodeschannel, nodesinfos, nodes, width=480, height=
             bxy=xy4nodeindex(((nodenumber*2)+1), nodecount*2, (cx,cy), radius)
             bx=xy[0]
             by=xy[1]
-            #draw.text((bx-(btw/2),by-(bth/2)), btt, font=ringfont, fill=breakcolor)
 #            vicarioustext.drawcenteredtext(draw,btt,24,bx,by,breakcolor)
         # sidebar text
         operator = str(nodenumber) + ". " + nodes[nodenumber]["operator"]


### PR DESCRIPTION
- REF: arthashdungeon.py refactored to use the common modules for bitcoin and text
- FIX: channelbalance.py now cleans up old images that were lingering as channels can open/close over time yielding less pages
- ENH: debug.py monitoring more generated images
- ENH: ipaddress.py adjusted to better accomodate MyNodeBTC which runs several docker containers on bridged IPs
- NEW: logo.py will take the referenced source image and scale up/down to the target dimensions with option to stretch top and bottom or the sides.
- REF: rofstatus.py removing some dead code