### PR TITLE
Fix some panel docs links and formatting

### DIFF
--- a/_docs/script-arthash.md
+++ b/_docs/script-arthash.md
@@ -13,23 +13,18 @@ This script produces geometric artwork deterministically based on Bitcoin
 Blockhash values. It depends on a bitcoin node running locally and fully
 synched.
 
-
 ![sample image depicting hash as colored triangles](../images/arthash-719360.png)
 
 ## Script Location
 
 The script is installed at 
-[../scripts/arthash.py](../scripts/arthash.py). 
+[~/nodeyez/scripts/arthash.py](../scripts/arthash.py). 
 
 ## Configuration
 
-To configure this script
+To configure this script, edit the `~/nodeyez/config/arthash.json` file
 
-Override the default configuration as follows
-
-```sh
-nano ../config/arthash.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -41,28 +36,24 @@ nano ../config/arthash.json
 | height | The height, in pixels, to generate the image. Default `320` |
 | sleepInterval | The amount of time, in seconds, the script should wait before data gathering and image creation again. Default `300` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+And run it
+```shell
 python arthash.py
 ```
 
 Press CTRL+C to stop the process
-
 
 ## Run at Startup
 
@@ -77,4 +68,3 @@ sudo systemctl start nodeyez-arthash.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-arthashdungeon.md
+++ b/_docs/script-arthashdungeon.md
@@ -20,15 +20,13 @@ synched.
 ## Script Location
 
 The script is installed at 
-[../scripts/arthashdungeon.py](../scripts/arthashdungeon.py). 
+[~/nodeyez/scripts/arthashdungeon.py](../scripts/arthashdungeon.py). 
 
 ## Configuration
 
-To configure this script, override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/arthashdungeon.json` file
 
-```shell
-nano ../config/arthashdungeon.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -41,23 +39,20 @@ nano ../config/arthashdungeon.json
 | height | The height, in pixels, to generate the image. Default `320` |
 | sleepInterval | The amount of time, in seconds, the script should wait before data gathering and image creation again. Default `300` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+And run it
+```shell
 python arthashdungeon.py
 ```
 
@@ -76,4 +71,3 @@ sudo systemctl start nodeyez-arthashdungeon.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-blockheight.md
+++ b/_docs/script-blockheight.md
@@ -17,15 +17,13 @@ It depends on a bitcoin node running locally and fully synched.
 ## Script Location
 
 The script is installed at 
-[../scripts/blockheight.py](../scripts/blockheight.py).
+[~/nodeyez/scripts/blockheight.py](../scripts/blockheight.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/blockheight.json` file
 
-```shell
-nano ../config/blockheight.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -36,23 +34,20 @@ nano ../config/blockheight.json
 | height | The height, in pixels, to generate the image. Default `320` |
 | sleepInterval | The amount of time, in seconds, the script should wait before data gathering and image creation again. Default `120` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Running Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python blockheight.py
 ```
 

--- a/_docs/script-blockstats.md
+++ b/_docs/script-blockstats.md
@@ -28,15 +28,13 @@ An additional image can be produced to graph segwit prevalence over time
 ## Script Location
 
 The script is installed at 
-[../scripts/blockstats.py](../scripts/blockstats.py).
+[~/nodeyez/scripts/blockstats.py](../scripts/blockstats.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/blockstats.json` file
 
-```shell
-nano ../config/blockstats.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -58,24 +56,20 @@ nano ../config/blockstats.json
 | showFeeRates | Indicates whether the fee rates image should be created. Default: `true` |
 | showSegwitPrevalence | Indicates whether the segwit prevalence image should be created. Default `true` |
 
-
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Running Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python blockstats.py
 ```
 
@@ -94,4 +88,3 @@ sudo systemctl start nodeyez-blockstats.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-braiinspool.md
+++ b/_docs/script-braiinspool.md
@@ -24,15 +24,13 @@ from this panel in future updates.
 ## Script Location
 
 This script is installed at
-[../scripts/braiinspool.py](../scripts/braiinspool.py)
+[~/nodeyez/scripts/braiinspool.py](../scripts/braiinspool.py)
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/braiinspool.json` file
 
-```shell
-nano ../config/braiinspool.json
-```
+Fields are defined below
 
 You must set the authtoken field with your API access token
 
@@ -61,23 +59,20 @@ You must set the authtoken field with your API access token
 | colorBreakEvenMiss | The color of the text showing the break even amount when it is not met expressed as a Hexadecimal color specifier. Default `#ff0000` |
 | colorBreakEvenGood | The color of the text showing the break even amount when it is met expressed as a Hexadecimal color specifier. Default `#00ff00` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-* To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python braiinspool.py
 ```
 
@@ -96,4 +91,3 @@ sudo systemctl start nodeyez-braiinspool.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-channelbalance.md
+++ b/_docs/script-channelbalance.md
@@ -19,16 +19,13 @@ It depends on a lighting node.
 ## Script Location
 
 The script is installed at 
-[../scripts/channelbalance.py](../scripts/channelbalance.py).
-
+[~/nodeyez/scripts/channelbalance.py](../scripts/channelbalance.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/channelbalance.json` file
 
-```shell
-nano ../config/channelbalance.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -71,24 +68,21 @@ nano ../config/channelbalance.json
 | height | Override the height, in pixels, to generate the image. |
 | pageSize | Override the number of channels to represent per page rendered. |
 | headerText | Override the text to use in the header area. |
-   
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
 
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python channelbalance.py
 ```
 
@@ -107,4 +101,3 @@ sudo systemctl start nodeyez-channelbalance.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-channelfees.md
+++ b/_docs/script-channelfees.md
@@ -19,15 +19,13 @@ number of open channels.  It depends on a lighting node.
 ## Script Location
 
 The script is installed at 
-[../scripts/channelfees.py](../scripts/channelfees.py).
+[~/nodeyez/scripts/channelfees.py](../scripts/channelfees.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/channelfees.json` file
 
-```shell
-nano ../config/channelfees.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -71,23 +69,20 @@ nano ../config/channelfees.json
 | pageSize | Override the number of channels to represent per page rendered. |
 | headerText | Override the text to use in the header area. |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python channelfees.py
 ```
 
@@ -106,4 +101,3 @@ sudo systemctl start nodeyez-channelfees.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-compassmininghardware.md
+++ b/_docs/script-compassmininghardware.md
@@ -17,15 +17,13 @@ Compass Mining reseller marketplace.
 ## Script Location
 
 The script is installed at 
-[../scripts/compassmininghardware.py](../scripts/compassmininghardware.py).
+[~/nodeyez/scripts/compassmininghardware.py](../scripts/compassmininghardware.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/compassmininghardware.json` file
 
-```shell
-nano ../config/compassmininghardware.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -46,28 +44,24 @@ nano ../config/compassmininghardware.json
 | height | The height, in pixels, to generate the image. Default `320` |
 | sleepInterval | The amount of time, in seconds, the script should wait before data gathering and image creation again. Default `3600` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python compassmininghardware.py
 ```
 
 Press CTRL+C to stop the process
-
 
 ## Run at Startup
 
@@ -79,8 +73,6 @@ sudo systemctl enable nodeyez-compassmininghardware.service
 sudo systemctl start nodeyez-compassmininghardware.service
 ```
 
-
 ---
 
 [Home](../) | 
-

--- a/_docs/script-compassminingstatus.md
+++ b/_docs/script-compassminingstatus.md
@@ -17,25 +17,13 @@ Compass Mining as reported on their [status page](https://status.compassmining.i
 ## Script Location
 
 The script is installed at 
-[../scripts/compassminingstatus.py](../scripts/compassminingstatus.py).
-
-## Dependencies
-
-Before running this script you must have met dependencies
-
-- beautifulsoup4 is required for compass mining scripts to parse HTML
-
-```shell
-python3 -m pip install beautifulsoup4
-```
+[~/nodeyez/scripts/compassminingstatus.py](../scripts/compassminingstatus.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/compassminingstatus.json` file
 
-```shell
-nano ../config/compassminingstatus.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -58,23 +46,20 @@ nano ../config/compassminingstatus.json
 | height | The height, in pixels, to generate the image. Default `320` |
 | sleepInterval | The amount of time, in seconds, the script should wait before data gathering and image creation again. Default `3600` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python compassminingstatus.py
 ```
 
@@ -93,4 +78,3 @@ sudo systemctl start nodeyez-compassminingstatus.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-daily-data-retrieval.md
+++ b/_docs/script-daily-data-retrieval.md
@@ -19,23 +19,7 @@ will also allow for more graphing trends.
 ## Script Location
 
 The script is installed at 
-[../scripts/daily-data-retrieval.py](../scripts/daily-data-retrieval.py).
-
-## Dependencies
-
-Before running this script you must have met dependencies
-
-- beautifulsoup4 is required for compass mining scripts to parse HTML
-
-```shell
-python3 -m pip install beautifulsoup4
-```
-
-- pandas is required for luxor scripts to use the client library for data retrieval
-
-```shell
-python3 -m pip install pandas
-```
+[~/nodeyez/scripts/daily-data-retrieval.py](../scripts/daily-data-retrieval.py).
 
 ## Configuration
 
@@ -60,19 +44,18 @@ overwrite your customizations to the script.
 
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python daily-data-retrieval.py
 ```
 

--- a/_docs/script-difficultyepoch.md
+++ b/_docs/script-difficultyepoch.md
@@ -21,15 +21,13 @@ It depends on a bitcoin node running locally and fully synched.
 
 ## Script Location
 The script is installed at
-[../scripts/difficultyepoch.py](../scripts/difficultyepoch.py).
+[~/nodeyez/scripts/difficultyepoch.py](../scripts/difficultyepoch.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/difficultyepoch.json` file
 
-```shell
-nano ../config/difficultyepoch.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -45,24 +43,20 @@ nano ../config/difficultyepoch.json
 | height | The height, in pixels, to generate the image. Default `320` |
 | sleepInterval | The amount of time, in seconds, the script should wait before data gathering and image creation again. Default `540` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python difficultyepoch.py
 ```
 
@@ -82,4 +76,3 @@ sudo systemctl start nodeyez-difficultyepoch.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-f2pool.md
+++ b/_docs/script-f2pool.md
@@ -22,20 +22,17 @@ file.
 ## Script Location
 
 The script is installed at
-[../scripts/f2pool.py](../scripts/f2pool.py).
+[~/nodeyez/scripts/f2pool.py](../scripts/f2pool.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/f2pool.json` file
 
-```sh
-nano ../config/f2pool.json
-```
+Fields are defined below
   
 You should set the following at a minimum
 - account
 - hashrateLowThreshold: recommend setting this to 10% below your expected hashrate.
-
 
 | field name | description |
 | --- | --- |
@@ -59,23 +56,20 @@ You should set the following at a minimum
 | height | The height, in pixels, to generate the image. Default `320` |
 | sleepInterval | The amount of time, in seconds, the script should wait before data gathering and image creation again. Default `600` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python f2pool.py
 ```
 
@@ -94,4 +88,3 @@ sudo systemctl start nodeyez-f2pool.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-fearandgreed.md
+++ b/_docs/script-fearandgreed.md
@@ -19,15 +19,13 @@ the top of the image.
 ## Script Location
 
 This script is installed at
-[../scripts/daily-data-retrieval.py](../scripts/daily-data-retrieval.py).
+[~/nodeyez/scripts/fearandgreed.py](../scripts/fearandgreed.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/fearandgreed.json` file
 
-```shell
-nano ../config/fearandgreed.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -45,25 +43,20 @@ nano ../config/fearandgreed.json
 | colorGraphLineDark | The color to draw the top and right and background dashed lines of the graph outline expressed as a Hexadecimal color specifier. Default `#606060` |
 | colorTextFG | The color of the text expressed as a Hexadecimal color specifier. Default `#ffffff` |
 
-
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python fearandgreed.py
 ```
 
@@ -82,4 +75,3 @@ sudo systemctl start nodeyez-daily-data-retrieval.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-fiatprice.md
+++ b/_docs/script-fiatprice.md
@@ -17,15 +17,13 @@ Bitcoin in US Dollar terms and then displays it graphically in large text
 ## Script Location
 
 The script is installed at
-[../scripts/fiatprice.py](../scripts/fiatprice.py).
+[~/nodeyez/scripts/fiatprice.py](../scripts/fiatprice.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/fiatprice.json` file
 
-```shell
-nano ../config/fiatprice.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -44,23 +42,20 @@ nano ../config/fiatprice.json
 | colorPriceDown | The color of the text for the current price when declining expressed as a Hexadecimal color specifier. Default `#ff4040ff` |
 | colorPriceShadow | The color of the text shadow for the current price expressed as a Hexadecimal color specifier. Default `#ffffff7f` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python fiatprice.py
 ```
 

--- a/_docs/script-gasprice.md
+++ b/_docs/script-gasprice.md
@@ -17,21 +17,19 @@ United States or Canada.
 ## Script Location
 
 The script is installed at
-[../scripts/gasprice.py](../scripts/gasprice.py).
+[~/nodeyez/scripts/gasprice.py](../scripts/gasprice.py).
 
 ## Dependencies
 
 It depends on data being retrieved from [collectapi](./config-collectapi.md) via the
-[../scripts/daily-data-retrieval.py)(../scripts/daily-data-retrieval.py)
+[~/nodeyez/scripts/daily-data-retrieval.py)(../scripts/daily-data-retrieval.py)
 script.
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/gasprice.json` file
 
-```shell
-nano ../config/gasprice.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -52,23 +50,20 @@ nano ../config/gasprice.json
 | height | The height, in pixels, to generate the image. Default `320` |
 | sleepInterval | The amount of time, in seconds, the script should wait before data gathering and image creation again. Default `3600` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python gasprice.py
 ```
 
@@ -87,4 +82,3 @@ sudo systemctl start nodeyez-gasprice.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-halving.md
+++ b/_docs/script-halving.md
@@ -19,15 +19,13 @@ is 210000 blocks, each whole percent represents 2100 blocs making for a nice lay
 ## Script Location
 
 The script is installed at 
-[../scripts/halving.py](../scripts/halving.py).
+[~/nodeyez/scripts/halving.py](../scripts/halving.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/halving.json` file
 
-```shell
-nano ../config/halving.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -44,23 +42,20 @@ nano ../config/halving.json
 | height | The height, in pixels, to generate the image. Default `320` |
 | sleepInterval | The amount of time, in seconds, the script should wait before data gathering and image creation again. Default `540` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-* To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python halving.py
 ```
 

--- a/_docs/script-inscriptionmempool.md
+++ b/_docs/script-inscriptionmempool.md
@@ -22,15 +22,13 @@ recent inscriptions will be generated as the output file.
 ## Script Location
 
 This script is installed at
-[../scripts/inscriptionmempool.py](../scripts/inscriptionmempool.py)
+[~/nodeyez/scripts/inscriptionmempool.py](../scripts/inscriptionmempool.py)
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/inscriptionmempool.json` file
 
-```sh
-nano ../config/inscriptionmempool.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -42,23 +40,20 @@ nano ../config/inscriptionmempool.json
 | colorTextFG | The color to use for the header expressed as a hexadecimal color specifier. Default `#ffffff` |
 | colorBackground | The background color of the image expressed as a hexadecimal color specifier. Default `#000000` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python inscriptionmempool.py
 ```
 
@@ -85,4 +80,3 @@ sudo systemctl start nodeyez-inscriptionmempool.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-ipaddress.md
+++ b/_docs/script-ipaddress.md
@@ -23,15 +23,13 @@ with Docker.
 ## Script Location
 
 The script is installed at
-[../scripts/ipaddress.py](../scripts/ipaddress.py).
+[~/nodeyez/scripts/ipaddress.py](../scripts/ipaddress.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/ipaddress.json` file
 
-```shell
-nano ../config/ipaddress.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -42,23 +40,20 @@ nano ../config/ipaddress.json
 | height | The height, in pixels, to generate the image. Default `320` |
 | sleepInterval | The amount of time, in seconds, the script should wait before data gathering and image creation again. Default `120` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the script folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python ipaddress.py
 ```
 
@@ -77,4 +72,3 @@ sudo systemctl start nodeyez-ipaddress.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-lndhub.md
+++ b/_docs/script-lndhub.md
@@ -39,15 +39,13 @@ me directly.
 ## Script Location
 
 This script is installed at
-[../scripts/lndhub.py](../scripts/lndhub.py).
+[~/nodeyez/scripts/lndhub.py](../scripts/lndhub.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/lndhub.json` file
 
-```shell
-nano ../config/lndhub.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -74,23 +72,20 @@ snippet in the config file as follows
 "f9095b00b85802c6ff9cc674231858af03a24a75353aa7c0": "Samantha"
 ```
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-* To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python lndhub.py
 ```
 
@@ -109,4 +104,3 @@ sudo systemctl start nodeyez-lndhub.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-luxor-mining-hashrate.md
+++ b/_docs/script-luxor-mining-hashrate.md
@@ -24,33 +24,13 @@ updated to use that common data.
 ## Script Location
 
 The script is installed at
-[../scripts/luxor-mining-hashrate.py](../scripts/luxor-mining-hashrate.py).
-
-## Dependencies
-
-At time of writing, this script uses a modified version of the 
-[Luxor Python Client](https://github.com/LuxorLabs/graphql-python-client). The
-files (luxor.py and resolvers.py) are already copied into this repo so no 
-additional action is required. A Pull Request has been opened with the upstream
-repository to include the change (forced sort order for the data). This PR
-has recently been merged and other enhancements have been made to the client
-that have not yet been brought into this project yet.  
-
-Before running this script you must have met dependencies
-
-- pandas is required for luxor scripts to use the client library for data retrieval
-
-```sh
-python3 -m pip install pandas
-```
+[~/nodeyez/scripts/luxor-mining-hashrate.py](../scripts/luxor-mining-hashrate.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/luxor.json` file
 
-```sh
-nano ../config/luxor.json
-```
+Fields are defined below
 
 - You must have an account with [Luxor](https://beta.luxor.tech/) and an
   API Key for that account. Read only access is sufficient
@@ -79,23 +59,20 @@ nano ../config/luxor.json
 | colorGraphLineLight | The color to use for the left and bottom borders of the plot graph, expressed as a Hexadecimal color specifier. Default `#a0a0a0` |
 | colorGraphLineDark | The color to use for the right and top borders of the blot graph, expressed as a Hexadecimal color specifier. Default `#606060` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python luxor-mining-hashrate.py
 ```
 
@@ -108,4 +85,3 @@ There is currently no service script defined for this script to run at startup
 ---
 
 [Home](../) | 
-

--- a/_docs/script-mempoolblocks.md
+++ b/_docs/script-mempoolblocks.md
@@ -23,15 +23,13 @@ can configure that instance instead for more privacy.
 ## Script Location
 
 The script is installed at 
-[../scripts/mempoolblocks.py](../scripts/mempoolblocks.py).
+[~/nodeyez/scripts/mempoolblocks.py](../scripts/mempoolblocks.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/mempoolblocks.json` file
 
-```shell
-nano ../config/mempoolblocks.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -111,23 +109,20 @@ histogramSatLevels: [
 ]
 ```
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python mempoolblocks.py
 ```
 
@@ -146,4 +141,3 @@ sudo systemctl start nodeyez-mempoolblocks.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-minerbraiins.md
+++ b/_docs/script-minerbraiins.md
@@ -20,15 +20,13 @@ is to improve for other miners over time.
 ## Script Location
 
 The script is installed at
-[../scripts/minerbraiins.py](../scripts/minerbraiins.py).
+[~/nodeyez/scripts/minerbraiins.py](../scripts/minerbraiins.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/minerbraiins.json` file
 
-```sh
-nano ../config/minerbraiins.json
-```
+Fields are defined below
 
 You must set the address for the miner
 
@@ -56,7 +54,6 @@ __miner__
 | minerlabel | A unique label to give this miner. If provided, it is used as the label in the header area of the image |
 | mineraddress | *required* The ip or host address for your miner on your local lan, accessible from the host running the script |
 | expectations | An optional structure defining expectations to monitor for. A setting out of range will cause a warning to be rendered. The structure is defined below |
-
 
 __expectations__
 
@@ -86,23 +83,20 @@ __pools__
 | url | The url for a pool that is expected to be configured |
 | user | The user for a pool that is expected to be configured in username.worker format |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python minerbraiins.py
 ```
 

--- a/_docs/script-minermicrobt.md
+++ b/_docs/script-minermicrobt.md
@@ -22,15 +22,13 @@ From API port 4028 on the miner it uses the data from pools+summary+devs
 ## Script Location
 
 The script is installed at 
-[../scripts/minermicrobt.py](../scripts/minermicrobt.py).
+[~/nodeyez/scripts/minermicrobt.py](../scripts/minermicrobt.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/minermicrobt.json` file
 
-```shell
-nano ../config/minermicrobt.json
-```
+Fields are defined below
 
 You must set the address for the miner
 
@@ -59,7 +57,6 @@ __miner__
 | minerlabel | A unique label to give this miner. If provided, it is used as the label in the header area of the image |
 | mineraddress | *required* The ip or host address for your miner on your local lan, accessible from the host running the script |
 | expectations | An optional structure defining expectations to monitor for. A setting out of range will cause a warning to be rendered. The structure is defined below |
-
 
 __expectations__
 
@@ -108,24 +105,20 @@ __fans__
 | low | An optional property to define the low end of expected fan speed, in RPMs. |
 | high | An optional property to define the high end of expected fan speed, in RPMs. |
 
-
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python minermicrobt.py
 ```
 
@@ -141,8 +134,6 @@ sudo systemctl enable nodeyez-minermicrobt.service
 sudo systemctl start nodeyez-minermicrobt.service
 ```
 
-
 ---
 
 [Home](../) |
-

--- a/_docs/script-nodeyezdual.md
+++ b/_docs/script-nodeyezdual.md
@@ -20,15 +20,13 @@ the bottom up.
 ## Script Location
 
 This script is installed at
-[../scripts/nodeyezdual.py](../scripts/nodeyezdual.py).
+[~/nodeyez/scripts/nodeyezdual.py](../scripts/nodeyezdual.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/nodeyezdual.json` file
 
-```sh
-nano ../config/nodeyezdual.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -44,23 +42,20 @@ nano ../config/nodeyezdual.json
 | dividerHeight | The height of an optional divider bar between images. Use 0 for no divider bar. Default 10 |
 | dividerBuffer | The height of optiona buffer between images and the divider bar. Use 0 for no buffer. Default 5 |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python nodeyezdual.py
 ```
 

--- a/_docs/script-opreturn.md
+++ b/_docs/script-opreturn.md
@@ -18,15 +18,13 @@ will be generated rendering the text values.
 ## Script Location
 
 The script is installed at
-[../scripts/opreturn.py](../scripts/opreturn.py).
+[~/nodeyez/scripts/opreturn.py](../scripts/opreturn.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/opreturn.json` file
 
-```shell
-nano ../config/opreturn.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -39,23 +37,20 @@ nano ../config/opreturn.json
 | colorTextFG1 | The primary color to use for OP_RETURN text expressed as a hexadecimal color specifier. Default `#ff7f00` |
 | colorTextFG2 | The alternate color to use for OP_RETURN text expressed as a hexadecimal color specifier. Default `#dddd00` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python opreturn.py
 ```
 
@@ -74,4 +69,3 @@ sudo systemctl start nodeyez-opreturn.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-ordinals.md
+++ b/_docs/script-ordinals.md
@@ -23,15 +23,13 @@ the image, the block, and the txid.
 ## Script Location
 
 This script is installed at
-[../scripts/ordinals.py](../scripts/ordinals.py).
+[~/nodeyez/scripts/ordinals.py](../scripts/ordinals.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/ordinals.json` file
 
-```sh
-nano ../config/ordinals.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -52,23 +50,20 @@ nano ../config/ordinals.json
 | blocklistURL | An optional URL to a resource that provides a list of block inscriptions not to extract. Default `https://nodeyez.com/sample-config/ordblocklist.json` |
 | useTor | Indicates whether remote calls should use torify for privacy. Experimental. Default `true` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python ordinals.py
 ```
 
@@ -78,16 +73,15 @@ This script also supports optional command line arguments for a single run and e
 
 1. Pass the desired block number or range as an argument as follows
 
-```sh
+```shell
 python ordinals.py 773046
 # or
 python ordinals.py 775000-775100
 ```
 
-
 2. Pass the desired block number or range, width and height as arguments
 
-```sh
+```shell
 python ordinals.py 774411 800 600
 # or
 python ordinals.py 775123-775223 1920 1080
@@ -106,4 +100,3 @@ sudo systemctl start nodeyez-ordinals.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-raretoshi.md
+++ b/_docs/script-raretoshi.md
@@ -19,25 +19,13 @@ Only static PNG and JPEG files are supported at this time.
 ## Script Location
 
 The script is installed at
-[../scripts/raretoshi.py](../scripts/raretoshi.py).
-
-## Dependencies
-
-Before running this script you must have met dependencies
-
-- qrcode is required to generate qr codes on the image to link to the asset
-
-```shell
-python3 -m pip install qrcode
-```
+[~/nodeyez/scripts/raretoshi.py](../scripts/raretoshi.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/raretoshi.json` file
 
-```shell
-nano ../config/raretoshi.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -62,23 +50,20 @@ nano ../config/raretoshi.json
 | qrCodeSize | If qrCodeEnabled is true, then this indicates the qr code box size for each pixel. Default `2` |
 | userInfoInterval | The amount of time, in seconds, the script should wait before refreshing the user information from raretoshi. Default `3600` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-* To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python raretoshi.py
 ```
 
@@ -97,4 +82,3 @@ sudo systemctl start nodeyez-raretoshi.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-rofstatus.md
+++ b/_docs/script-rofstatus.md
@@ -25,16 +25,13 @@ connection attempts, there is a delay between each ring being processed.
 ## Script Location
 
 The script is installed at 
-[../scripts/rofstatus.py](../scripts/rofstatus.py)
-
+[~/nodeyez/scripts/rofstatus.py](../scripts/rofstatus.py)
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/rofstatus.json` file
 
-```shell
-nano ../config/rofstatus.json
-```
+Fields are defined below
 
 | field name | description  |
 | ------------- |---------------------------------------- |
@@ -44,13 +41,11 @@ nano ../config/rofstatus.json
 | imagesettings | The default settings to apply to images generated unless overridden within a ring. The structure is defined below. |
 | rings | An array collection of defined rings to monitor and produce images for. The structure is defined below. |
 
-
 __imagesettings__
 
 | field name | description |
 | --- | --- |
 | colors | A structure of the color settings to apply to image generated. The structure is defined below |
-
 
 __colors__
 
@@ -65,7 +60,6 @@ __colors__
 | textshadow | The default color of the text shadow for the ring name expressed as a Hexadecimal color specifier. Default `#000000` |
 | background | The background color of the image expressed as a Hexadecimal color specifier. Default `#000000` |
 
-
 __rings__
 
 | field name | description |
@@ -78,7 +72,6 @@ __rings__
 | imagesettings | The settings to apply to the image generated from this ring. The structure is defined above |
 | nodes | An array of node objects where each represents a lightning node participant in this ring, in order. The structure is defined below |
 
-
 __node__
 
 | field name | description |
@@ -87,23 +80,20 @@ __node__
 | operator | A short label to identify the node |
 
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python rofstatus.py
 ```
 
@@ -119,8 +109,6 @@ sudo systemctl enable nodeyez-rofstatus.service
 sudo systemctl start nodeyez-rofstatus.service
 ```
 
-
 ---
 
 [Home](../) | 
-

--- a/_docs/script-satsperusd.md
+++ b/_docs/script-satsperusd.md
@@ -18,15 +18,13 @@ graphically
 ## Script Location
 
 This script is installed at
-[/home/nodeyez/nodeyz/scripts/satsperusd.py](../scripts/satsperusd.py).
+[~/nodeyez/scripts/satsperusd.py](../scripts/satsperusd.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/satsperusd.json` file
 
-```shell
-nano ../config/satsperusd.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -46,23 +44,20 @@ nano ../config/satsperusd.json
 | colorSatAmount | The color of the text for the current sats per dollar expressed as a Hexadecimal color specifier. Default `#4040407f` |
 | colorSatAmountShadow | The color of the text shadow for the current sats per dollar expressed as a Hexadecimal color specifier. Default `#ffffff7f` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python satsperusd.py
 ```
 
@@ -78,8 +73,6 @@ sudo systemctl enable nodeyez-satsperusd.service
 sudo systemctl start nodeyez-satsperusd.service
 ```
 
-
 ---
 
 [Home](../) | 
-

--- a/_docs/script-sysinfo.md
+++ b/_docs/script-sysinfo.md
@@ -22,16 +22,13 @@ LND, etc.
 ## Script Location
 
 This script is installed at
-[../scripts/sysinfo.py](../scripts/sysinfo.py)
-
+[~/nodeyez/scripts/sysinfo.py](../scripts/sysinfo.py)
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/sysinfo.json` file
 
-```sh
-nano ../config/sysinfo.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -69,23 +66,20 @@ nano ../config/sysinfo.json
 | colorMEMDanger | The color to fill the memory arc for used memory when in the danger rnage expressed as a Hexadecimal color specifier. Default `#ff0000` |
 | colorMEMLabelText | The color of the labels for the memory arc displays expressed as a Hexadecimal color specifier. Default `#ffffff` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-* To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python sysinfo.py
 ```
 
@@ -104,4 +98,3 @@ sudo systemctl start nodeyez-sysinfo.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-utcclock.md
+++ b/_docs/script-utcclock.md
@@ -15,15 +15,13 @@ This script provides a simple rendering of the date and time
 
 ## Script Location
 This script is installed at
-[../scripts/utcclock.py](../scripts/utcclock.py)
+[~/nodeyez/scripts/utcclock.py](../scripts/utcclock.py)
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/utcclock.json` file
 
-```shell
-nano ../config/utcclock.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -36,23 +34,20 @@ nano ../config/utcclock.json
 | colorTextDate | The color to render the current date expressed as a Hexadecimal color specifier. Default `#f1c232` |
 | colorTextTime | The color to render the current time expressed as a Hexadecimal color specifier. Default `#6aa84f` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-* To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python utcclock.py
 ```
 
@@ -71,4 +66,3 @@ sudo systemctl start nodeyez-utcclock.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-whirlpoolclimix.md
+++ b/_docs/script-whirlpoolclimix.md
@@ -1,5 +1,5 @@
 ---
-panelgroup: Other Fun Stuff
+panelgroup: Other Fun Panels
 name: Whirlpool CLI Mix Status
 title: Whirlpool CLI Mix Status script
 layout: default
@@ -18,15 +18,13 @@ generates a status panel of this information.
 ## Script Location
 
 This script is installed at
-[../scripts/whirlpoolclimax.py](../scripts/whirlpoolclimax.py).
+[~/nodeyez/scripts/whirlpoolclimax.py](../scripts/whirlpoolclimax.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/whirlpoolclimix.json` file
 
-```sh
-nano ../config/whirlpoolclimix.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -45,23 +43,20 @@ nano ../config/whirlpoolclimix.json
 | colorDataOff | The color of the indicator when something is off/false. Default `#ff4040` |
 | colorTextFG | The color of all other text labels and values expressed as a Hexadecimal color specifier. Default `#ffffff` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```
 python whirlpoolclimix.py
 ```
 
@@ -80,4 +75,3 @@ sudo systemctl start nodeyez-whirlpoolclimix.service
 ---
 
 [Home](../) | 
-

--- a/_docs/script-whirlpoolliquidity.md
+++ b/_docs/script-whirlpoolliquidity.md
@@ -18,15 +18,13 @@ the information.
 ## Script Location
 
 This script is installed at
-[../scripts/whirlpoolliquidity.py](../scripts/whirlpoolliquidity.py).
+[~/nodeyez/scripts/whirlpoolliquidity.py](../scripts/whirlpoolliquidity.py).
 
 ## Configuration
 
-To configure this script override the default configuration as follows
+To configure this script, edit the `~/nodeyez/config/whirlpoolliquidity.json` file
 
-```shell
-nano ../config/whirlpoolliquidity.json
-```
+Fields are defined below
 
 | field name | description |
 | --- | --- |
@@ -46,23 +44,20 @@ nano ../config/whirlpoolliquidity.json
 | colorElapsed | The color of the text label for elapsed time expressed as a Hexadecimal color specifier. Default `#aaaaaa` |
 | colorTextFG | The color of all other text labels and values expressed as a Hexadecimal color specifier. Default `#ffffff` |
 
-After making changes, Save (CTRL+O) and Exit (CTRL+X) nano.
-
 ## Run Directly
 
-To run this script
-
 Ensure the virtual environment is activated
-
 ```shell
 source ~/.pyenv/nodeyez/bin/activate
 ```
 
-And then run it
-
+Change to the scripts folder
 ```shell
 cd ~/nodeyez/scripts
+```
 
+Run it
+```shell
 python whirlpoolliquidity.py
 ```
 
@@ -78,8 +73,6 @@ sudo systemctl enable nodeyez-whirlpoolliquidity.service
 sudo systemctl start nodeyez-whirlpoolliquidity.service
 ```
 
-
 ---
 
 [Home](../) | 
-


### PR DESCRIPTION
Consistent formatting for all panel documentation pages.
Removed references to nano as not necessary, user can choose their own editor.
Fixed script link for fearandgreed.
Fixed jekyll theme grouping for Whirlpool CLI Mix

