### PR TITLE
Fix Sysinfo display for single drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ title: NODEYEZ Change Log
 **General**
 
 - Linking tagged commits back to Github as a public mirror
+- Add guidance for Development Environment
 
 **Bugfixes**
 
+- Fix display of System Info drive icons if only one drive
 
 ## 23.03
 

--- a/_install_steps/9developer.md
+++ b/_install_steps/9developer.md
@@ -87,8 +87,6 @@ From the Search bar, look for and install the following extensions:
 
 - systemd-unit-file [from coolbear]: Language support for systemd unit files
 
-- View Image for Python Debugging [from Elazar Cohen] - simply view the image of the image variables when debugging python
-
 ## Choose Python Interpreter
 
 When in Visual Studio Code, we want to make sure that we're using the environment that we setup previously.  Access the command palette by either the shortcut (CTRL+SHIFT+P) or from the View menu.

--- a/scripts/sysinfo.py
+++ b/scripts/sysinfo.py
@@ -117,19 +117,17 @@ def createimage(width=480, height=320):
     im = Image.new(mode="RGB", size=(width, height), color=colorBackground)
     draw = ImageDraw.Draw(im)
     drawicon(draw,"thermometer",5,5,bw-10,bh-10,v=str(gettemp()))
-    #drawicon(draw,"sdcard",5+bw,5,bw-10,bh-10,v=str(getdrivefree("/dev/root")))
     # Drive 1 (SDCard or Root)
     drive1info = vicariousstat.getdrive1info()                  # ('/', '21G', '74') = tuple of mount point, free space, free percent
     drive1infov = "X X X " + drive1info[1] + " " + str(100-int(drive1info[2])) + "% " + drive1info[0]
     drawicon(draw,"piestorage",5+bw,5,bw-10,bh-10,drive1infov)
-    vicarioustext.drawcenteredtext(draw, "Root Drive", int(bw*.15), (5+bw)+((bh-10)/2), 5+((bh-10)*.08), colorHeader, True)    
-    #drawicon(draw,"hdd",5+bw+bw,5,bw-10,bh-10,v=str(getdrivefree("/dev/sda1")))
+    vicarioustext.drawcenteredtext(draw, "Root Drive", int(bw*.15), (5+bw)+((bh-10)/2), 5+((bh-10)*.08), colorHeader, True)
     # Drive 2 (External HDD)
     drive2info = vicariousstat.getdrive2info()                  # ('/mnt/hdd', '254G', '29') = tuple of mount point, free space, free percent
     if drive2info[0] != "None":
         drive2infov = "X X X " + drive2info[1] + " " + str(100-int(drive2info[2])) + "% " + drive2info[0]
         drawicon(draw,"piestorage",5+bw+bw,5,bw-10,bh-10,drive2infov)
-        vicarioustext.drawcenteredtext(draw, "2nd Drive", int(bw*.15), (5+bw)+((bh-10)/2), 5+((bh-10)*.08), colorHeader, True)    
+        vicarioustext.drawcenteredtext(draw, "2nd Drive", int(bw*.15), (5+bw)+((bh-10)/2), 5+((bh-10)*.08), colorHeader, True)
     drawicon(draw,"cpuload",5,bh+5,bw,bh-10,v=str(getloadavg()))
     drawicon(draw,"memory",5+bw,bh+5,bw,bh-10,v=str(getmemusage("Mem","RAM")))
     drawicon(draw,"memory",5+bw+bw,bh+5,bw,bh-10,v=str(getmemusage("Swap","Swap")))

--- a/scripts/sysinfo.py
+++ b/scripts/sysinfo.py
@@ -7,6 +7,7 @@ import math
 import subprocess
 import sys
 import time
+import vicariousstat
 import vicarioustext
 
 def drawicon(draw,icon,x,y,w,h,v=None):
@@ -72,12 +73,6 @@ def drawicon(draw,icon,x,y,w,h,v=None):
         draw.pieslice(xy=(x+pad+ox,y+pad+oy,x+w+ox-pad,y+h+oy-pad),start=sa,end=ea,fill=colorPieEmpty,outline=colorPieOutline,width=1)
         vicarioustext.drawbottomlefttext(draw, "free", int(w*.10), x+(w/2)+ox, y+(h/2)-int(h*.05), colorPieEmptyText)
         vicarioustext.drawcenteredtext(draw, gbf + " free", int(w*.125), x+(w/2), y+h-int(h*.0625), colorPieLabelText)
-    if icon == "sdcard":
-        drawicon(draw,"piestorage",x,y,w,h,v)
-        vicarioustext.drawcenteredtext(draw, "/dev/root", int(w*.15), x+int(w/2), y+int(h*.08), colorHeader, True)
-    if icon == "hdd":
-        drawicon(draw,"piestorage",x,y,w,h,v)
-        vicarioustext.drawcenteredtext(draw, "/dev/sda1", int(w*.15), x+int(w/2), y+int(h*.08), colorHeader, True)
     if icon == "cpuload":
         vicarioustext.drawcenteredtext(draw, "CPU Load", int(w*.15), x+int(w/2), y+int(h*.08), colorHeader, True)
         vicarioustext.drawlefttext(draw, "1 min", int(w*.1125), x+int(w*.0375), y+(int(h/8)*3), colorCPULabelText)
@@ -122,8 +117,19 @@ def createimage(width=480, height=320):
     im = Image.new(mode="RGB", size=(width, height), color=colorBackground)
     draw = ImageDraw.Draw(im)
     drawicon(draw,"thermometer",5,5,bw-10,bh-10,v=str(gettemp()))
-    drawicon(draw,"sdcard",5+bw,5,bw-10,bh-10,v=str(getdrivefree("/dev/root")))
-    drawicon(draw,"hdd",5+bw+bw,5,bw-10,bh-10,v=str(getdrivefree("/dev/sda1")))
+    #drawicon(draw,"sdcard",5+bw,5,bw-10,bh-10,v=str(getdrivefree("/dev/root")))
+    # Drive 1 (SDCard or Root)
+    drive1info = vicariousstat.getdrive1info()                  # ('/', '21G', '74') = tuple of mount point, free space, free percent
+    drive1infov = "X X X " + drive1info[1] + " " + str(100-int(drive1info[2])) + "% " + drive1info[0]
+    drawicon(draw,"piestorage",5+bw,5,bw-10,bh-10,drive1infov)
+    vicarioustext.drawcenteredtext(draw, "Root Drive", int(bw*.15), (5+bw)+((bh-10)/2), 5+((bh-10)*.08), colorHeader, True)    
+    #drawicon(draw,"hdd",5+bw+bw,5,bw-10,bh-10,v=str(getdrivefree("/dev/sda1")))
+    # Drive 2 (External HDD)
+    drive2info = vicariousstat.getdrive2info()                  # ('/mnt/hdd', '254G', '29') = tuple of mount point, free space, free percent
+    if drive2info[0] != "None":
+        drive2infov = "X X X " + drive2info[1] + " " + str(100-int(drive2info[2])) + "% " + drive2info[0]
+        drawicon(draw,"piestorage",5+bw+bw,5,bw-10,bh-10,drive2infov)
+        vicarioustext.drawcenteredtext(draw, "2nd Drive", int(bw*.15), (5+bw)+((bh-10)/2), 5+((bh-10)*.08), colorHeader, True)    
     drawicon(draw,"cpuload",5,bh+5,bw,bh-10,v=str(getloadavg()))
     drawicon(draw,"memory",5+bw,bh+5,bw,bh-10,v=str(getmemusage("Mem","RAM")))
     drawicon(draw,"memory",5+bw+bw,bh+5,bw,bh-10,v=str(getmemusage("Swap","Swap")))

--- a/scripts/vicariousstat.py
+++ b/scripts/vicariousstat.py
@@ -99,13 +99,13 @@ def getdriveratio(path="/$"):
 
 # get drive2 path
 def getdrive2path():
-    cmd = "lsblk --output MOUNTPOINT | grep / | grep -v /boot | grep -v /snap | sort | wc -l"
+    cmd = "df -t ext4 | grep / | awk '{print $6}' | sort | wc -l"
     try:
         cmdoutput = subprocess.check_output(cmd, shell=True).decode("utf-8").strip()
         if len(cmdoutput) > 0:
             drivecount = int(cmdoutput)
             if drivecount > 1:
-                cmd = "lsblk --output MOUNTPOINT | grep / | grep -v /boot | grep -v /snap | sort | sed -n 2p"
+                cmd = "df -t ext4 | grep / | awk '{print $6}' | sort | sed -n 2p"
                 drive2path = subprocess.check_output(cmd, shell=True).decode("utf-8").strip()
                 return drive2path
     except subprocess.CalledProcessError as e:

--- a/scripts/vicariousstat.py
+++ b/scripts/vicariousstat.py
@@ -99,18 +99,19 @@ def getdriveratio(path="/$"):
 
 # get drive2 path
 def getdrive2path():
-    cmd = "lsblk --output MOUNTPOINT | grep / | grep -v /boot | sort | wc -l"
+    cmd = "lsblk --output MOUNTPOINT | grep / | grep -v /boot | grep -v /snap | sort | wc -l"
     try:
         cmdoutput = subprocess.check_output(cmd, shell=True).decode("utf-8").strip()
         if len(cmdoutput) > 0:
             drivecount = int(cmdoutput)
             if drivecount > 1:
-                cmd = "lsblk --output MOUNTPOINT | grep / | grep -v /boot | sort | sed -n 2p"
+                cmd = "lsblk --output MOUNTPOINT | grep / | grep -v /boot | grep -v /snap | sort | sed -n 2p"
                 drive2path = subprocess.check_output(cmd, shell=True).decode("utf-8").strip()
                 return drive2path
     except subprocess.CalledProcessError as e:
         print(e)
         return "?"
+    return None
 
 # get drive1 info
 def getdrive1info():
@@ -122,7 +123,7 @@ def getdrive1info():
 # get drive2 info
 def getdrive2info():
     drive2path = getdrive2path()
-    if drive2path == "?":
+    if drive2path is None or drive2path == "?":
         return "None", 0, 0
     else:
         drivefree = getdrivefree(drive2path)


### PR DESCRIPTION
- Use piestorage icon directly as per nodeyezdual, and eliminate sdcard and hdd opinionated variants
- For second drive, exclude /snap mount points and handle None return